### PR TITLE
Changing public nic-configs for the new lab switch setup

### DIFF
--- a/roles/overcloud-prepare-templates/files/nic-configs/13/public/1029p-controller.yaml
+++ b/roles/overcloud-prepare-templates/files/nic-configs/13/public/1029p-controller.yaml
@@ -158,20 +158,17 @@ resources:
               - type: ovs_bridge
                 name: br-ex
                 use_dhcp: false
+                addresses:
+                - ip_netmask:
+                    get_param: ExternalIpSubnet
+                routes:
+                - default: true
+                  next_hop:
+                    get_param: ExternalInterfaceDefaultRoute
                 members:
                 - type: interface
                   name: enp94s0f3
                   primary: true
-                - type: vlan
-                  vlan_id:
-                    get_param: ExternalNetworkVlanID
-                  addresses:
-                  - ip_netmask:
-                      get_param: ExternalIpSubnet
-                  routes:
-                  - default: true
-                    next_hop:
-                      get_param: ExternalInterfaceDefaultRoute
 
 outputs:
   OS::stack_id:

--- a/roles/overcloud-prepare-templates/tasks/main.yml
+++ b/roles/overcloud-prepare-templates/tasks/main.yml
@@ -36,7 +36,7 @@
     owner: stack
     group: stack
   with_items:
-    - src: templates/create_public_cluster_network.sh.j2
-      dest: /home/stack/alderaan-deploy/create_public_cluster_network.sh
+    - src: templates/create_external_cluster_network.sh.j2
+      dest: /home/stack/alderaan-deploy/create_external_cluster_network.sh
     - src: templates/post_deploy_workarounds.sh.j2
       dest: /home/stack/alderaan-deploy/post_deploy_workarounds.sh

--- a/roles/overcloud-prepare-templates/templates/create_external_cluster_network.sh.j2
+++ b/roles/overcloud-prepare-templates/templates/create_external_cluster_network.sh.j2
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -x
+
+usage ()
+{
+  echo "Creates the cluster external network. Either a public (flat/untagged) or private (vlan tagged) network can be created."
+  echo ""
+  echo "Usage: create_external_cluster_network.sh public,private"
+  echo ""
+  echo "Ex:"
+  echo "create_external_cluster_network.sh public"
+  echo "create_external_cluster_network.sh private"
+  echo ""
+}
+
+source /home/stack/overcloudrc
+
+if [ -z "$1" ]; then
+  usage
+  exit 1
+elif [ "$1" == "public" ]; then
+  openstack network create --share --external --provider-physical-network datacentre --provider-network-type flat public --format json
+elif [ "$1" == "private" ]; then
+  openstack network create --share --external --provider-physical-network datacentre --provider-network-type vlan --provider-segment {{ external_vlan }} public --format json
+else
+  usage
+  exit 1
+fi
+
+openstack subnet create --allocation-pool start={{fip_pool_start}},end={{fip_pool_end}} --gateway={{external_network_gateway}} --no-dhcp --dns-nameserver {{dns_server}} --network public --subnet-range {{external_network_cidr}} public_subnet --format json

--- a/roles/overcloud-prepare-templates/templates/create_public_cluster_network.sh.j2
+++ b/roles/overcloud-prepare-templates/templates/create_public_cluster_network.sh.j2
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -x
-openstack network create --share --external --provider-physical-network datacentre --provider-network-type vlan --provider-segment {{ external_vlan }} public --format json
-openstack subnet create --allocation-pool start={{fip_pool_start}},end={{fip_pool_end}} --gateway={{external_network_gateway}} --no-dhcp --dns-nameserver {{dns_server}} --network public --subnet-range {{external_network_cidr}} public_subnet --format json

--- a/roles/overcloud-prepare-templates/templates/post_deploy_workarounds.sh.j2
+++ b/roles/overcloud-prepare-templates/templates/post_deploy_workarounds.sh.j2
@@ -7,6 +7,8 @@ else
 fi
 date -u >> ${log}
 
+source /home/stack/stackrc
+
 {% if version == '13' %}
 # Fix Ceph pg/pgp counts
 {% for pool in ceph_pools %}

--- a/roles/post-deploy/tasks/main.yml
+++ b/roles/post-deploy/tasks/main.yml
@@ -3,12 +3,16 @@
 # Tasks for post deployment
 #
 
-- name: Create the public network and subnet
+- name: Create the public external network and subnet
   shell: |
-    . /home/stack/overcloudrc
-    /home/stack/alderaan-deploy/create_public_cluster_network.sh
+    /home/stack/alderaan-deploy/create_external_cluster_network.sh public
+  when: external_network_setup == "11_public" or external_network_setup == "13_public"
+
+- name: Create the private external network and subnet
+  shell: |
+    /home/stack/alderaan-deploy/create_external_cluster_network.sh private
+  when: external_network_setup == "11_private" or external_network_setup == "13_private"
 
 - name: Run post deploy workarounds
   shell: |
-    . /home/stack/stackrc
     /home/stack/alderaan-deploy/post_deploy_workarounds.sh {{log_dir}}

--- a/vars/deploy.yml
+++ b/vars/deploy.yml
@@ -110,7 +110,6 @@ external_network_setup: "{{ lookup('env', 'OSP_EXTERNAL_NETWORK_SETUP')|default(
 
 # Settings for both Network Setups
 dns_server: "{{ lookup('env', 'OSP_DNS_SERVER') }}"
-external_vlan: "{{ lookup('env', 'OSP_EXTERNAL_VLAN')|default('10', true) }}"
 external_network_pool_start: "{{ lookup('env', 'OSP_EXTERNAL_NET_POOL_START')|default('172.21.0.3', true) }}"
 external_network_pool_end: "{{ lookup('env', 'OSP_EXTERNAL_NET_POOL_END')|default('172.21.0.254', true) }}"
 external_network_gateway: "{{ lookup('env', 'OSP_EXTERNAL_NET_GATEWAY')|default('172.21.0.1', true) }}"
@@ -122,6 +121,9 @@ fip_pool_start: "{{ lookup('env', 'OSP_FIP_POOL_START')|default('172.21.1.1', tr
 fip_pool_end: "{{ lookup('env', 'OSP_FIP_POOL_END')|default('172.21.255.254', true) }}"
 
 # Network settings specific to private external network setup
+# External vlan IDs are only in use for the private external network according to the latest scalelab iteration
+external_vlan: "{{ lookup('env', 'OSP_EXTERNAL_VLAN')|default('10', true) }}"
+
 undercloud_public_interface: "{{ lookup('env', 'OSP_UNDERCLOUD_PUBLIC_INTERFACE')|default('eno1', true) }}"
 undercloud_external_vlan_device: "{{ lookup('env', 'OSP_UNDERCLOUD_PRIVATE_EXTERNAL_INTERFACE')|default('enp94s0f3', true) }}.{{external_vlan}}"
 


### PR DESCRIPTION
Latest run on the new lab means we no longer need an external vlan id